### PR TITLE
Improve workflow

### DIFF
--- a/.github/workflows/fetch-crowdin-translations.yml
+++ b/.github/workflows/fetch-crowdin-translations.yml
@@ -83,3 +83,13 @@ jobs:
         --body "Merged translations from Crowdin"
       env:
         GITHUB_TOKEN: ${{ github.token }}
+    - name: Manually trigger generateFolderForAddonAuthors workflow
+      uses: actions/github-script@v8
+      with:
+        script: |
+        await github.rest.actions.createWorkflowDispatch({
+          owner: context.repo.owner,
+          repo: context.repo.repo,
+          workflow_id: 'generateFolderForAddonAuthors.yml',
+          ref: '${{ github.ref_name }}'
+        });

--- a/.github/workflows/generateFolderForAddonAuthors.yml
+++ b/.github/workflows/generateFolderForAddonAuthors.yml
@@ -2,10 +2,6 @@ name: Generate folder for add-on authors
 
 on:
   workflow_dispatch:
-  
-  schedule:
-    # Every Monday at 00:05 UTC
-    - cron: '5 0 * * 1'
 jobs:
   generateSharedFolder:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Cancel the planned run of generateFolderForAddonAuthors.yml, and manually trigger it by GitHUB Actions after the original step of fetch-crowdin-translations.yml is successfully run.
Because I think GitHUB's plan is not very reliable.